### PR TITLE
errors are handled except for _document.tsx

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -73,7 +73,7 @@ export default function AppBarComponent() {
   const SignOut = async () => {
     try {
       router.push("/sign-in");
-      await auth.signOut(); //[TODO]サインアウとしてからsign-inページにプッシュされるので、一瞬dashboardに戻ることになって落ちてしまう
+      await auth.signOut().catch((err) => console.error(err)); //[TODO]サインアウとしてからsign-inページにプッシュされるので、一瞬dashboardに戻ることになって落ちてしまう
     } catch (error) {
       alert(error.message);
     }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -73,8 +73,12 @@ MyDocument.getInitialProps = async (ctx) => {
       enhanceApp: (App) => (props) => sheets.collect(<App {...props} />),
     });
 
+  // const initialProps = await Document.getInitialProps(ctx).catch((err) => {
+  //   console.error(err);
+  // });
   const initialProps = await Document.getInitialProps(ctx);
 
+  // errorハンドリングしたら下も出し分ける必要あるが、ハンドリングすると型が合わなくなる
   return {
     ...initialProps,
     // Styles fragment is rendered after the app and page rendering finish.


### PR DESCRIPTION
`_document.tsx`だけ、型が合わなくなってしまうのでハンドリングしていない箇所がある。